### PR TITLE
react should be a peer dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "ava test.js",
     "example": "parcel example.html"
   },
-  "dependencies": {
+  "peerDependencies": {
     "react": "^16.7.0-alpha.0"
   },
   "devDependencies": {


### PR DESCRIPTION
otherwise yarn will install react in "@rehooks/window-size/node_modules/react", which will break, as react 16.7.0 does not have hooks yet.