### PR TITLE
Fix issue with SSR

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,23 +1,26 @@
 'use strict';
 let { useState, useEffect } = require('react');
 
-function getSize() {
-  return {
-    innerHeight: window.innerHeight,
-    innerWidth: window.innerWidth,
-    outerHeight: window.outerHeight,
-    outerWidth: window.outerWidth,
-  };
-}
-
 function useWindowSize() {
+  let isClient = typeof window === 'object';
   let [windowSize, setWindowSize] = useState(getSize());
+
+  function getSize() {
+    return {
+      innerHeight: isClient ? window.innerHeight : undefined,
+      innerWidth: isClient ? window.innerWidth : undefined,
+      outerHeight: isClient ? window.outerHeight : undefined,
+      outerWidth: isClient ? window.outerWidth : undefined
+    };
+  }
 
   function handleResize() {
     setWindowSize(getSize());
   }
 
   useEffect(() => {
+    if (!isClient) return undefined;
+
     window.addEventListener('resize', handleResize);
     return () => {
       window.removeEventListener('resize', handleResize);


### PR DESCRIPTION
Using this hook in an SSR environment will cause a crash since it assumes that the `window` object is available. This PR fixes that by checking if `window` is available before accessing it.