### PR TITLE
feat: don't mutate windowSize object if sizes don't change

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,19 @@
 'use strict';
-let { useState, useEffect } = require('react');
+let { useState, useEffect, useMemo } = require('react');
 
-function getSize() {
-  return {
+function useWindowSize() {
+  const getSize = useMemo(() => () => ({
     innerHeight: window.innerHeight,
     innerWidth: window.innerWidth,
     outerHeight: window.outerHeight,
     outerWidth: window.outerWidth,
-  };
-}
-
-function useWindowSize() {
+  }), [
+    window.innerHeight,
+    window.innerWidth,
+    window.outerHeight,
+    window.outerWidth,
+  ]);
+  
   let [windowSize, setWindowSize] = useState(getSize());
 
   function handleResize() {


### PR DESCRIPTION
Sorry, I wanted to open an issue rather than a PR because:

1. I don't know if you want to implement this
2. I don't have time to work on it with the chance you will reject it

But you have disabled issues for this repository, so here's a lame attempt.

Basically, I'd like to be able to just do:

```
const windowSize = useWindowSize();
useEffect(() => /* something on resize */, [windowSize]);
```